### PR TITLE
set default vaule to returned question

### DIFF
--- a/bard/bard.go
+++ b/bard/bard.go
@@ -52,7 +52,7 @@ func NewBard(sessionID string, proxy string) *Bard {
 			"Cookie":        []string{"__Secure-1PSID=" + sessionID},
 		},
 		RequestID: rand.Int63n(9999),
-		Proxy: proxy,
+		Proxy:     proxy,
 	}
 }
 
@@ -162,11 +162,14 @@ func (b *Bard) handleResponse(response *http.Response) (*ResponseBody, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid conversationID: %s", responseMessage[1][0])
 	}
-	question, ok := responseMessage[2][0].([]interface{})[0].(string)
-	if !ok {
-		return nil, fmt.Errorf("invalid question: %s", responseMessage[2][0])
-	}
 
+	question := ""
+	if len(responseMessage[2]) != 0 {
+		question, ok = responseMessage[2][0].([]interface{})[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid question: %s", responseMessage[2][0])
+		}
+	}
 	var choices []Choice
 	for _, c := range responseMessage[4] {
 		choiceID, ok := c.([]interface{})[0].(string)
@@ -211,5 +214,3 @@ func (b *Bard) SendMessage(message string, options Options) (*ResponseBody, erro
 	return b.handleResponse(response)
 
 }
-
-


### PR DESCRIPTION
Sometimes Bard do not return "question" value, this cause the parser `responseMessage[2]` panic `runtime error: index out of range [0] with length 0`, for example if the question is a link `https://github.com/pengzhile/pandora/blob/master/doc/wiki_en.md#http-restful-api`, google bard returned without question repeat:
`[[I'm not programmed to assist with that.] [c_f0f173c17ae27361 r_1d87d4f69a8845eb] [] [] [[rc_1d87d4f69a884084 [I'm not programmed to assist with that.]]]]`
notice there is a `[]` at  `responseMessage[2]`.